### PR TITLE
Allow branches to be filtered by regexp.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,6 @@ the main settings navigation. Then set
 
 `semaphorestatus --all` to show all local branches
 
+`semaphorestatus --regex <regular expression>` to filter branches by a regular expression
+
 `semaphorestatus` to show only your local branches


### PR DESCRIPTION
Regexes need to be strings to prevent them form being executed on the command line.
