### PR TITLE
Rely on remote tracking branch, rather than local branch name, to filter...

### DIFF
--- a/lib/localBranches.js
+++ b/lib/localBranches.js
@@ -3,10 +3,14 @@ var sys   = require('sys');
 var exec  = require('child_process').exec;
 var child;
 
+function extractRelativeBranchName(line) {
+  var fullBranch = line.substring(line.indexOf('[') + 1, line.lastIndexOf(']'));
+  return fullBranch.substring(fullBranch.indexOf('/') + 1);
+}
+
 exports.get = function(cb) {
-  child = exec("git branch", function(err, stdout, stderr) {
-    cb(err, _.map(stdout.split('\n'), function(val) {
-      return val.substring(2, val.length);
-    }));
+  child = exec("git branch -vv", function(err, stdout, stderr) {
+    cb(err, _.map(stdout.split('\n'), extractRelativeBranchName));
   });
 };
+


### PR DESCRIPTION
....
