### PR TITLE
Fix vulnerable dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,22 +5,27 @@
   "main": "bin/semaphore-status.js",
   "dependencies": {
     "colors": "~0.6.0-1",
-    "moment": "~1.7.2",
-    "request": "~2.12.0",
+    "moment": "~2.24.0",
+    "request": "~2.68.0",
     "underscore": "~1.4.4"
   },
   "devDependencies": {
     "mocha": "latest"
   },
-  "bin": {"semaphore-status": "bin/semaphore-status.js"},
+  "bin": {
+    "semaphore-status": "bin/semaphore-status.js"
+  },
   "scripts": {
     "test": "mocha test"
   },
   "repository": {
-      "type": "git",
-      "url": "https://github.com/mojotech/semaphorestatus.git"
-    },
+    "type": "git",
+    "url": "https://github.com/mojotech/semaphorestatus.git"
+  },
   "author": "MojoTech",
-  "contributors": ["Sam Saccone @sam_saccone", "Matt Forsyth"],
+  "contributors": [
+    "Sam Saccone @sam_saccone",
+    "Matt Forsyth"
+  ],
   "license": "BSD"
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "devDependencies": {
     "mocha": "latest"
   },
+  "engines": {
+    "node": ">=1.0.0"
+  },
   "bin": {
     "semaphore-status": "bin/semaphore-status.js"
   },


### PR DESCRIPTION
Upgrade `moment` and `request` packages. 

Also it starts requiring Node v1.0 as the minimum engine to run `semaphorestatus`.